### PR TITLE
Fix diff to show original filename of test

### DIFF
--- a/bin/tush-check
+++ b/bin/tush-check
@@ -47,5 +47,5 @@ do
 
     < "${f}" $expand_cmd > $expanded
 
-    (tush-run "${f}" | diff $ignore_blanks -u $expanded -) || exit 1
+    (tush-run "${f}" | diff --label "${f} expected" --label "${f} actual" $ignore_blanks -u $expanded -) || exit 1
 done

--- a/tests/basic.tush
+++ b/tests/basic.tush
@@ -20,14 +20,16 @@ $ tush-check test.tush >/dev/null
 ? 1
 ```
 
-Here, `tail -n +3` skips the first lines from `diff -u` which include
-dates that will vary from one run to the next:
+Same as above but expect the diff output.
 
 ```sh
-$ tush-check test.tush | tail -n +3
+$ tush-check test.tush
+| --- test.tush expected
+| +++ test.tush actual
 | @@ -1 +1,2 @@
 |  $ echo hello world
 | +| hello world
+? 1
 ```
 
 Using `tush-bless` we fix this test failure:


### PR DESCRIPTION
Before this change, the diff showed the expanded filename.  The expanded file is reused for each test so it does not contain any information to identify the failing test.  This made it difficult to find out which test failed.

Fix by using the test filename as the diff label.  Additionally label expected output vs actual output.
### Before Change

``` text
$ tush-check test.tush
--- tush-expanded.I4kSN 2016-10-22 22:17:17.963963100 -0700
+++ -   2016-10-22 22:17:18.002558700 -0700
@@ -1 +1,2 @@
 $ echo hello world
+| hello world
```
### After Change

``` text
$ tush-check test.tush
--- test.tush expected
+++ test.tush actual
@@ -1 +1,2 @@
 $ echo hello world
+| hello world
```
