### PR TITLE
Add ability to customize diff command used

### DIFF
--- a/bin/tush-check
+++ b/bin/tush-check
@@ -12,6 +12,7 @@ usage()
 
 expand_cmd=cat
 ignore_blanks=
+diff=${DIFF:-diff}
 
 while getopts bhx opt; do
     case $opt in
@@ -47,5 +48,5 @@ do
 
     < "${f}" $expand_cmd > $expanded
 
-    (tush-run "${f}" | diff --label "${f} expected" --label "${f} actual" $ignore_blanks -u $expanded -) || exit 1
+    (tush-run "${f}" | $diff --label "${f} expected" --label "${f} actual" $ignore_blanks -u $expanded -) || exit 1
 done


### PR DESCRIPTION
For example, diffs could be colorized with:

    env DIFF=colordiff tush-check <file>

![image](https://cloud.githubusercontent.com/assets/28975/20028138/a045df82-a2e6-11e6-96da-ab1447674eab.png)

